### PR TITLE
support 'attachment-row' content type

### DIFF
--- a/extract.ps1
+++ b/extract.ps1
@@ -111,6 +111,12 @@ function Get-ChainContent($chain) {
 				$attachment = $block.attachment
 				@{img=@{altText=$attachment | ?. altText; fileUrl=$attachment.fileURL}}
 			}
+			'attachment-row' {
+				foreach ($att in $block.attachments) {
+					$attachment = $att.attachment
+					@{img=@{altText=$attachment | ?. altText; fileUrl=$attachment.fileURL}}
+				}
+			}
 			default {
 				Write-Error "unknown content type $($block.type)"
 			}


### PR DESCRIPTION
This type is from the new post editor pushed into public preview during the site's shutdown period. This implementation seems to work on some of my own posts, at least.